### PR TITLE
Add default WHATWG ReadableStream stream support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ yarn add node-readable-to-web-readable-stream
 
 ## Usage
 
-Here's how you can use this utility to convert a [Node.js stream.Readable](https://nodejs.org/api/stream.html#class-streamreadable) stream into a [WHATWG / Web API ReadableStream](https://developer.mozilla.org/docs/Web/API/ReadableStream):
+You can either convert to a [WHATWG / Web API ReadableStream](https://developer.mozilla.org/docs/Web/API/ReadableStream) byte mode, or default mode.
+
+Here's how you can use this utility to convert a [Node.js stream.Readable](https://nodejs.org/api/stream.html#class-streamreadable) stream into a byte [WHATWG / Web API ReadableStream](https://developer.mozilla.org/docs/Web/API/ReadableStream):
+If you want to use a [ReadableStreamBYOBReader](https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBReader) you should use this method.
 
 ```javascript
 import {makeByteReadableStreamFromNodeReadable} from 'node-readable-to-web-readable-stream';
@@ -37,8 +40,23 @@ const nodeReadable = fs.createReadStream('example.txt');
 // Convert to a web ReadableStream
 const webReadable = makeByteReadableStreamFromNodeReadable(nodeReadable);
 
-// Now you can use webReadable as a WHATWG ReadableStream
+// Now you can use webReadable as a WHATWG ReadableStream in byte mode
 ```
+
+If you want to use a [ReadableStreamDefaultReader](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultReader) you should use this method.
+```javascript
+import {makeDefaultReadableStreamFromNodeReadable} from 'node-readable-to-web-readable-stream';
+import {createReadStream} from 'fs';
+
+// Create a Node.js Readable stream
+const nodeReadable = fs.createReadStream('example.txt');
+
+// Convert to a web ReadableStream
+const webReadable = makeDefaultReadableStreamFromNodeReadable(nodeReadable);
+
+// Now you can use webReadable as a WHATWG default ReadableStream
+```
+
 
 ## Compatibility
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,284 +1,423 @@
-import {makeByteReadableStreamFromNodeReadable} from '../lib/index.js';
+import {makeByteReadableStreamFromNodeReadable, makeDefaultReadableStreamFromNodeReadable} from '../lib/index.js';
 import path from 'node:path';
 import {describe, it} from "mocha";
 import {assert} from "chai";
 import {fileURLToPath} from "node:url";
 import {PassThrough} from "node:stream";
-import {makeByteReadableStreamFromFile, SourceStream} from "./util.js";
+import {makeByteReadableStreamFromFile, makeDefaultReadableStreamFromFile, SourceStream} from "./util.js";
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
 
-describe('ReadableStreamDefaultReader', () => {
+describe('Default ReadableStream From Node Readable', () => {
 
-  it('read more data then available', async () => {
+  describe('ReadableStreamDefaultReader', () => {
 
-    const filePath = path.join(dirname, 'sample', 'bach-goldberg-variatians-05.sv8.mpc');
+    it('read more data then available', async () => {
 
-    const webStream = await makeByteReadableStreamFromFile(filePath);
-    try {
-      const reader = webStream.stream.getReader();
+      const filePath = path.join(dirname, 'sample', 'bach-goldberg-variatians-05.sv8.mpc');
+
+      const webStream = await makeDefaultReadableStreamFromFile(filePath);
       try {
-        let bytesRemaining = 4100;
-        let bytesRead = 0;
-        let result
-        do {
-          result = await reader.read();
-          if (result.done) break;
-          bytesRemaining -= result.value.length;
-          bytesRead += result.value.length;
-        } while ((bytesRemaining > 0));
-        assert.strictEqual(bytesRead, 3346, 'bytes read');
-      } finally {
-        reader.releaseLock();
-      }
-    } finally {
-      webStream.stream.cancel();
-    }
-  });
-
-  it('read more data then available #2', async () => {
-    const nodeReadable = new SourceStream('123');
-    try {
-      const webReadableStream = makeByteReadableStreamFromNodeReadable(nodeReadable);
-      try {
-        const streamReader = webReadableStream.getReader();
+        const reader = webStream.stream.getReader();
         try {
-          let res = await streamReader.read();
-          assert.strictEqual(res.done, false, 'result.done');
-          assert.equal(res.value.length, 3, 'should indicate only 3 bytes are actually read');
-          res = await streamReader.read();
-          assert.strictEqual(res.done, true, 'result.done');
-        } finally {
-          streamReader.releaseLock();
-        }
-      } finally {
-        await webReadableStream.cancel();
-      }
-    } finally {
-      nodeReadable.destroy();
-    }
-  });
-
-  it('read from a streamed data chunk', async () => {
-    const nodeReadable = new SourceStream('\x05peter');
-    try {
-      const webReadableStream = makeByteReadableStreamFromNodeReadable(nodeReadable);
-      try {
-        const streamReader = webReadableStream.getReader();
-        try {
-
-          let buf;
-          let res;
-
-          // read only one byte from the chunk
-          res = await streamReader.read();
-          assert.strictEqual(res.done, false, 'result.done');
-          assert.strictEqual(res.value.length, 6, 'Should read exactly one byte');
-          assert.strictEqual(res.value[0], 5, '0x05 == 5');
-          assert.strictEqual(new TextDecoder('latin1').decode(res.value.subarray(1)), 'peter');
-
-          // should reject at the end of the stream
-          buf = new Uint8Array(1);
-          res = await streamReader.read(buf);
-          assert.strictEqual(res.done, true, 'should indicate end of stream');
-        } finally {
-          streamReader.releaseLock();
-        }
-      } finally {
-        await webReadableStream.cancel();
-      }
-    } finally {
-      nodeReadable.destroy();
-    }
-  });
-
-  it('should apply backpressure, when data is not consumed', async () => {
-    const nodePassThrough = new PassThrough();
-    try {
-      const webReadableStream = makeByteReadableStreamFromNodeReadable(nodePassThrough);
-      try {
-        const streamReader = webReadableStream.getReader();
-        try {
-          let result;
-          let bytesWritten = 0;
-          let pushMoreData;
-          assert.isFalse(nodePassThrough.isPaused(), 'Node Readable is not paused of initialization');
-          do {
-            const data = new Uint8Array(256);
-            pushMoreData = nodePassThrough.push(data);
-            bytesWritten += data.length;
-         } while(pushMoreData && bytesWritten < 128 * 1024);
-          assert.isFalse(pushMoreData, 'Should eventually backpressure');
-          assert.isTrue(nodePassThrough.isPaused(), 'Node Readable is paused');
+          let bytesRemaining = 4100;
           let bytesRead = 0;
+          let result
           do {
-            const {value, done} = await streamReader.read();
-            assert.isFalse(done, 'Read stream result');
-            bytesRead += value.length;
-         } while(bytesRead < bytesWritten);
-          const prom = streamReader.read(); // Read more than there is available
-          assert.isFalse(nodePassThrough.isPaused(), 'Node Readable is paused after reading all bytes written');
-          do {
-            const data = new Uint8Array(256);
-            pushMoreData = nodePassThrough.push(data);
-            bytesWritten += data.length;
-          } while(pushMoreData && bytesWritten < 128 * 1024);
-          await prom;
-          assert.isTrue(nodePassThrough.isPaused(), 'Node Readable is paused');
+            result = await reader.read();
+            if (result.done) break;
+            bytesRemaining -= result.value.length;
+            bytesRead += result.value.length;
+          } while ((bytesRemaining > 0));
+          assert.strictEqual(bytesRead, 3346, 'bytes read');
         } finally {
-          streamReader.releaseLock();
+          reader.releaseLock();
         }
       } finally {
-        await webReadableStream.cancel();
+        webStream.stream.cancel();
       }
-    } finally {
-      nodePassThrough.destroy();
-    }
+    });
+
+    it('read more data then available #2', async () => {
+      const nodeReadable = new SourceStream('123');
+      try {
+        const webReadableStream = makeDefaultReadableStreamFromNodeReadable(nodeReadable);
+        try {
+          const streamReader = webReadableStream.getReader();
+          try {
+            let res = await streamReader.read();
+            assert.strictEqual(res.done, false, 'result.done');
+            assert.equal(res.value.length, 3, 'should indicate only 3 bytes are actually read');
+            res = await streamReader.read();
+            assert.strictEqual(res.done, true, 'result.done');
+          } finally {
+            streamReader.releaseLock();
+          }
+        } finally {
+          await webReadableStream.cancel();
+        }
+      } finally {
+        nodeReadable.destroy();
+      }
+    });
+
+    it('read from a streamed data chunk', async () => {
+      const nodeReadable = new SourceStream('\x05peter');
+      try {
+        const webReadableStream = makeDefaultReadableStreamFromNodeReadable(nodeReadable);
+        try {
+          const streamReader = webReadableStream.getReader();
+          try {
+
+            let buf;
+            let res;
+
+            // read only one byte from the chunk
+            res = await streamReader.read();
+            assert.strictEqual(res.done, false, 'result.done');
+            assert.strictEqual(res.value.length, 6, 'Should read exactly one byte');
+            assert.strictEqual(res.value[0], 5, '0x05 == 5');
+            assert.strictEqual(new TextDecoder('latin1').decode(res.value.subarray(1)), 'peter');
+
+            // should reject at the end of the stream
+            buf = new Uint8Array(1);
+            res = await streamReader.read(buf);
+            assert.strictEqual(res.done, true, 'should indicate end of stream');
+          } finally {
+            streamReader.releaseLock();
+          }
+        } finally {
+          await webReadableStream.cancel();
+        }
+      } finally {
+        nodeReadable.destroy();
+      }
+    });
+
+    it('should apply backpressure, when data is not consumed', async () => {
+      const nodePassThrough = new PassThrough();
+      try {
+        const webReadableStream = makeDefaultReadableStreamFromNodeReadable(nodePassThrough);
+        try {
+          const streamReader = webReadableStream.getReader();
+          try {
+            let result;
+            let bytesWritten = 0;
+            let pushMoreData;
+            assert.isFalse(nodePassThrough.isPaused(), 'Node Readable is not paused of initialization');
+            do {
+              const data = new Uint8Array(256);
+              pushMoreData = nodePassThrough.push(data);
+              bytesWritten += data.length;
+            } while(pushMoreData && bytesWritten < 128 * 1024);
+            assert.isFalse(pushMoreData, 'Should eventually backpressure');
+            assert.isTrue(nodePassThrough.isPaused(), 'Node Readable is paused');
+            let bytesRead = 0;
+            do {
+              const {value, done} = await streamReader.read();
+              assert.isFalse(done, 'Read stream result');
+              bytesRead += value.length;
+            } while(bytesRead < bytesWritten);
+            const prom = streamReader.read(); // Read more than there is available
+            assert.isFalse(nodePassThrough.isPaused(), 'Node Readable is paused after reading all bytes written');
+            do {
+              const data = new Uint8Array(256);
+              pushMoreData = nodePassThrough.push(data);
+              bytesWritten += data.length;
+            } while(pushMoreData && bytesWritten < 128 * 1024);
+            await prom;
+            assert.isTrue(nodePassThrough.isPaused(), 'Node Readable is paused');
+          } finally {
+            streamReader.releaseLock();
+          }
+        } finally {
+          await webReadableStream.cancel();
+        }
+      } finally {
+        nodePassThrough.destroy();
+      }
+    });
   });
 });
 
-describe('ReadableStreamBYOBReader', () => {
+describe('Byte ReadableStream from Node Readable', () => {
 
-  const mode = 'byob';
+  describe('ReadableStreamDefaultReader', () => {
 
-  it('read more data then available', async () => {
+    it('read more data then available', async () => {
 
-    const filePath = path.join(dirname, 'sample', 'bach-goldberg-variatians-05.sv8.mpc');
+      const filePath = path.join(dirname, 'sample', 'bach-goldberg-variatians-05.sv8.mpc');
 
-    const webStream = await makeByteReadableStreamFromFile(filePath);
-    try {
-      const reader = webStream.stream.getReader({mode: 'byob'});
+      const webStream = await makeByteReadableStreamFromFile(filePath);
       try {
-        const bytesRequested = 4100;
-        let bytesRemaining = bytesRequested;
-        let bytesRead = 0;
-        let result;
-        do {
-          result = await reader.read(new Uint8Array(bytesRemaining));
-          if (result.done) break;
-          bytesRemaining -= result.value.length;
-          bytesRead += result.value.length;
-        } while ((bytesRemaining > 0));
-        assert.strictEqual(bytesRead, 3346, 'bytes read');
-      } finally {
-        reader.releaseLock();
-      }
-    } finally {
-      webStream.stream.cancel();
-    }
-  });
-
-  it('read more data then available #2', async () => {
-    const nodeReadable = new SourceStream('123');
-    try {
-      const webReadableStream = makeByteReadableStreamFromNodeReadable(nodeReadable);
-      try {
-        const streamReader = webReadableStream.getReader({mode: 'byob'});
+        const reader = webStream.stream.getReader();
         try {
-
-          let res;
-          let buf = new Uint8Array(4);
-          res = await streamReader.read(buf);
-          assert.strictEqual(res.done, false, 'result.done');
-          assert.equal(res.value.length, 3, 'should indicate only 3 bytes are actually read');
-          buf = new Uint8Array(4);
-          res = await streamReader.read(buf);
-          assert.strictEqual(res.done, true, 'result.done');
-        } finally {
-          streamReader.releaseLock();
-        }
-      } finally {
-        await webReadableStream.cancel();
-      }
-    } finally {
-      nodeReadable.destroy();
-    }
-  });
-
-  it('read from a streamed data chunk', async () => {
-    const nodeReadable = new SourceStream('\x05peter');
-    try {
-      const webReadableStream = makeByteReadableStreamFromNodeReadable(nodeReadable);
-      try {
-        const streamReader = webReadableStream.getReader({mode: 'byob'});
-        try {
-
-          let buf;
-          let res;
-
-          // read only one byte from the chunk
-          buf = new Uint8Array(1);
-          res = await streamReader.read(buf);
-          assert.strictEqual(res.done, false, 'result.done');
-          assert.strictEqual(res.value.length, 1, 'Should read exactly one byte');
-          assert.strictEqual(res.value[0], 5, '0x05 == 5');
-
-          // should decode string from chunk
-          buf = new Uint8Array(5);
-          res = await streamReader.read(buf);
-          assert.strictEqual(res.done, false, 'result.done');
-          assert.strictEqual(res.value.length, 5, 'Should read 5 bytes');
-          assert.strictEqual(new TextDecoder('latin1').decode(res.value), 'peter');
-
-          // should reject at the end of the stream
-          buf = new Uint8Array(1);
-          res = await streamReader.read(buf);
-          assert.strictEqual(res.done, true, 'should indicate end of stream');
-        } finally {
-          streamReader.releaseLock();
-        }
-      } finally {
-        await webReadableStream.cancel();
-      }
-    } finally {
-      nodeReadable.destroy();
-    }
-  });
-
-  it('should apply backpressure, when data is not consumed', async () => {
-    const nodePassThrough = new PassThrough();
-    try {
-      const webReadableStream = makeByteReadableStreamFromNodeReadable(nodePassThrough);
-      try {
-        const streamReader = webReadableStream.getReader({mode: 'byob'});
-        try {
-          let result;
-          let bytesWritten = 0;
-          const data = new Uint8Array(256);
-          let pushMoreData;
-          assert.isFalse(nodePassThrough.isPaused(), 'Node Readable should not be paused after initialization');
-          do {
-            pushMoreData = nodePassThrough.push(data);
-            bytesWritten += data.length;
-          } while(pushMoreData && bytesWritten < 32 * 1024);
-          assert.isTrue(nodePassThrough.isPaused(), 'Node Readable is paused');
-
+          let bytesRemaining = 4100;
           let bytesRead = 0;
+          let result
           do {
+            result = await reader.read();
+            if (result.done) break;
+            bytesRemaining -= result.value.length;
+            bytesRead += result.value.length;
+          } while ((bytesRemaining > 0));
+          assert.strictEqual(bytesRead, 3346, 'bytes read');
+        } finally {
+          reader.releaseLock();
+        }
+      } finally {
+        webStream.stream.cancel();
+      }
+    });
+
+    it('read more data then available #2', async () => {
+      const nodeReadable = new SourceStream('123');
+      try {
+        const webReadableStream = makeByteReadableStreamFromNodeReadable(nodeReadable);
+        try {
+          const streamReader = webReadableStream.getReader();
+          try {
+            let res = await streamReader.read();
+            assert.strictEqual(res.done, false, 'result.done');
+            assert.equal(res.value.length, 3, 'should indicate only 3 bytes are actually read');
+            res = await streamReader.read();
+            assert.strictEqual(res.done, true, 'result.done');
+          } finally {
+            streamReader.releaseLock();
+          }
+        } finally {
+          await webReadableStream.cancel();
+        }
+      } finally {
+        nodeReadable.destroy();
+      }
+    });
+
+    it('read from a streamed data chunk', async () => {
+      const nodeReadable = new SourceStream('\x05peter');
+      try {
+        const webReadableStream = makeByteReadableStreamFromNodeReadable(nodeReadable);
+        try {
+          const streamReader = webReadableStream.getReader();
+          try {
+
+            let buf;
+            let res;
+
+            // read only one byte from the chunk
+            res = await streamReader.read();
+            assert.strictEqual(res.done, false, 'result.done');
+            assert.strictEqual(res.value.length, 6, 'Should read exactly one byte');
+            assert.strictEqual(res.value[0], 5, '0x05 == 5');
+            assert.strictEqual(new TextDecoder('latin1').decode(res.value.subarray(1)), 'peter');
+
+            // should reject at the end of the stream
+            buf = new Uint8Array(1);
+            res = await streamReader.read(buf);
+            assert.strictEqual(res.done, true, 'should indicate end of stream');
+          } finally {
+            streamReader.releaseLock();
+          }
+        } finally {
+          await webReadableStream.cancel();
+        }
+      } finally {
+        nodeReadable.destroy();
+      }
+    });
+
+    it('should apply backpressure, when data is not consumed', async () => {
+      const nodePassThrough = new PassThrough();
+      try {
+        const webReadableStream = makeByteReadableStreamFromNodeReadable(nodePassThrough);
+        try {
+          const streamReader = webReadableStream.getReader();
+          try {
+            let result;
+            let bytesWritten = 0;
+            let pushMoreData;
+            assert.isFalse(nodePassThrough.isPaused(), 'Node Readable is not paused of initialization');
+            do {
+              const data = new Uint8Array(256);
+              pushMoreData = nodePassThrough.push(data);
+              bytesWritten += data.length;
+            } while(pushMoreData && bytesWritten < 128 * 1024);
+            assert.isFalse(pushMoreData, 'Should eventually backpressure');
+            assert.isTrue(nodePassThrough.isPaused(), 'Node Readable is paused');
+            let bytesRead = 0;
+            do {
+              const {value, done} = await streamReader.read();
+              assert.isFalse(done, 'Read stream result');
+              bytesRead += value.length;
+            } while(bytesRead < bytesWritten);
+            const prom = streamReader.read(); // Read more than there is available
+            assert.isFalse(nodePassThrough.isPaused(), 'Node Readable is paused after reading all bytes written');
+            do {
+              const data = new Uint8Array(256);
+              pushMoreData = nodePassThrough.push(data);
+              bytesWritten += data.length;
+            } while(pushMoreData && bytesWritten < 128 * 1024);
+            await prom;
+            assert.isTrue(nodePassThrough.isPaused(), 'Node Readable is paused');
+          } finally {
+            streamReader.releaseLock();
+          }
+        } finally {
+          await webReadableStream.cancel();
+        }
+      } finally {
+        nodePassThrough.destroy();
+      }
+    });
+  });
+
+  describe('ReadableStreamBYOBReader', () => {
+
+    const mode = 'byob';
+
+    it('read more data then available', async () => {
+
+      const filePath = path.join(dirname, 'sample', 'bach-goldberg-variatians-05.sv8.mpc');
+
+      const webStream = await makeByteReadableStreamFromFile(filePath);
+      try {
+        const reader = webStream.stream.getReader({mode: 'byob'});
+        try {
+          const bytesRequested = 4100;
+          let bytesRemaining = bytesRequested;
+          let bytesRead = 0;
+          let result;
+          do {
+            result = await reader.read(new Uint8Array(bytesRemaining));
+            if (result.done) break;
+            bytesRemaining -= result.value.length;
+            bytesRead += result.value.length;
+          } while ((bytesRemaining > 0));
+          assert.strictEqual(bytesRead, 3346, 'bytes read');
+        } finally {
+          reader.releaseLock();
+        }
+      } finally {
+        webStream.stream.cancel();
+      }
+    });
+
+    it('read more data then available #2', async () => {
+      const nodeReadable = new SourceStream('123');
+      try {
+        const webReadableStream = makeByteReadableStreamFromNodeReadable(nodeReadable);
+        try {
+          const streamReader = webReadableStream.getReader({mode: 'byob'});
+          try {
+
+            let res;
+            let buf = new Uint8Array(4);
+            res = await streamReader.read(buf);
+            assert.strictEqual(res.done, false, 'result.done');
+            assert.equal(res.value.length, 3, 'should indicate only 3 bytes are actually read');
+            buf = new Uint8Array(4);
+            res = await streamReader.read(buf);
+            assert.strictEqual(res.done, true, 'result.done');
+          } finally {
+            streamReader.releaseLock();
+          }
+        } finally {
+          await webReadableStream.cancel();
+        }
+      } finally {
+        nodeReadable.destroy();
+      }
+    });
+
+    it('read from a streamed data chunk', async () => {
+      const nodeReadable = new SourceStream('\x05peter');
+      try {
+        const webReadableStream = makeByteReadableStreamFromNodeReadable(nodeReadable);
+        try {
+          const streamReader = webReadableStream.getReader({mode: 'byob'});
+          try {
+
+            let buf;
+            let res;
+
+            // read only one byte from the chunk
+            buf = new Uint8Array(1);
+            res = await streamReader.read(buf, {min: buf.length});
+            assert.strictEqual(res.done, false, 'result.done');
+            assert.strictEqual(res.value.length, 1, 'Should read exactly one byte');
+            assert.strictEqual(res.value[0], 5, '0x05 == 5');
+
+            // should decode string from chunk
+            buf = new Uint8Array(5);
+            res = await streamReader.read(buf, {min: buf.length});
+            assert.strictEqual(res.value.length, 5, 'Should read 5 bytes');
+            assert.strictEqual(new TextDecoder('latin1').decode(res.value), 'peter');
+
+            if (!res.done) {
+              // should reject at the end of the stream, if not already done
+              buf = new Uint8Array(1);
+              res = await streamReader.read(buf);
+              assert.strictEqual(res.done, true, 'should indicate end of stream');
+            }
+          } finally {
+            streamReader.releaseLock();
+          }
+        } finally {
+          await webReadableStream.cancel();
+        }
+      } finally {
+        nodeReadable.destroy();
+      }
+    });
+
+    it('should apply backpressure, when data is not consumed', async () => {
+      const nodePassThrough = new PassThrough();
+      try {
+        const webReadableStream = makeByteReadableStreamFromNodeReadable(nodePassThrough);
+        try {
+          const streamReader = webReadableStream.getReader({mode: 'byob'});
+          try {
+            let result;
+            let bytesWritten = 0;
+            const data = new Uint8Array(256);
+            let pushMoreData;
+            assert.isFalse(nodePassThrough.isPaused(), 'Node Readable should not be paused after initialization');
+            do {
+              pushMoreData = nodePassThrough.push(data);
+              bytesWritten += data.length;
+            } while(pushMoreData && bytesWritten < 32 * 1024);
+            assert.isTrue(nodePassThrough.isPaused(), 'Node Readable is paused');
+
+            let bytesRead = 0;
+            do {
+              const buf = new Uint8Array(256);
+              const {value, done} = await streamReader.read(buf);
+              assert.isFalse(done, 'Read stream result');
+              bytesRead += value.length;
+            } while(bytesRead < bytesWritten);
             const buf = new Uint8Array(256);
-            const {value, done} = await streamReader.read(buf);
-            assert.isFalse(done, 'Read stream result');
-            bytesRead += value.length;
-          } while(bytesRead < bytesWritten);
-          const buf = new Uint8Array(256);
-          const prom = streamReader.read(buf); // Read more than there is available
-          assert.isFalse(nodePassThrough.isPaused(), 'Node Readable is paused after reading all bytes written');
-          do {
-            pushMoreData = nodePassThrough.push(data);
-            bytesWritten += data.length;
-          } while(pushMoreData && bytesWritten < 64 * 1024);
-          await prom;
-          assert.isTrue(nodePassThrough.isPaused(), 'Node Readable is paused');
+            const prom = streamReader.read(buf); // Read more than there is available
+            assert.isFalse(nodePassThrough.isPaused(), 'Node Readable is paused after reading all bytes written');
+            do {
+              pushMoreData = nodePassThrough.push(data);
+              bytesWritten += data.length;
+            } while(pushMoreData && bytesWritten < 64 * 1024);
+            await prom;
+            assert.isTrue(nodePassThrough.isPaused(), 'Node Readable is paused');
+          } finally {
+            streamReader.releaseLock();
+          }
         } finally {
-          streamReader.releaseLock();
+          await webReadableStream.cancel();
         }
       } finally {
-        await webReadableStream.cancel();
+        nodePassThrough.destroy();
       }
-    } finally {
-      nodePassThrough.destroy();
-    }
+    });
   });
+
 });
+
+
 

--- a/test/util.js
+++ b/test/util.js
@@ -1,7 +1,18 @@
 import {stat} from "node:fs/promises";
 import {createReadStream} from "node:fs";
 import {Readable} from "node:stream";
-import {makeByteReadableStreamFromNodeReadable} from "../lib/index.js";
+import {makeByteReadableStreamFromNodeReadable, makeDefaultReadableStreamFromNodeReadable} from "../lib/index.js";
+
+export async function makeDefaultReadableStreamFromFile(filename) {
+
+  const fileInfo = await stat(filename);
+  const nodeStream = createReadStream(filename);
+
+  return {
+    fileSize: fileInfo.size,
+    stream: makeDefaultReadableStreamFromNodeReadable(nodeStream)
+  };
+}
 
 export async function makeByteReadableStreamFromFile(filename) {
 
@@ -13,6 +24,7 @@ export async function makeByteReadableStreamFromFile(filename) {
     stream: makeByteReadableStreamFromNodeReadable(nodeStream)
   };
 }
+
 
 /**
  * A mock Node.js readable-stream, using string to read from


### PR DESCRIPTION
Add method `makeDefaultReadableStreamFromNodeReadable()` supporting Web API **default** ReadableStream.